### PR TITLE
Menu accessibility improvements

### DIFF
--- a/_includes/partials/navbar.html
+++ b/_includes/partials/navbar.html
@@ -56,7 +56,7 @@
     function closeMenu(btn) {
         const menu = document.getElementById(btn.getAttribute('aria-controls'));
 
-        menu.setAttribute('inert', ''); /*Unlike visibility, makes menu items uninteractive during close animation*/
+        menu.setAttribute('inert', ''); /*Unlike visibility, immediately makes menu items uninteractive during close animation*/
         btn.setAttribute('aria-expanded', 'false');
     }
 

--- a/_includes/partials/navbar.html
+++ b/_includes/partials/navbar.html
@@ -53,18 +53,36 @@
 <script>
     const buttons = ['nav_menu_button', 'language_switcher_button'];
 
+    function closeMenu(btn) {
+        btn.setAttribute('aria-expanded', 'false');
+    }
+
+    function openMenu(btn) {
+        /*Close any other open menu first*/
+        for (const btnId of buttons) {
+            if (btnId !== btn.id) {
+                closeMenu(document.getElementById(btnId));
+            }
+        };
+
+        btn.setAttribute('aria-expanded', 'true');
+    }
+
     for (const btnId of buttons) {
         const btn = document.getElementById(btnId);
 
         btn.addEventListener('click', function () {
-            const btnState = btn.getAttribute('aria-expanded') === 'true';
-            btn.setAttribute('aria-expanded', String(!btnState));
+            if (btn.getAttribute('aria-expanded') === 'true') {
+                closeMenu(btn);
+            } else {
+                openMenu(btn);
+            }
         });
 
         /*Escape key closes menu*/
         document.addEventListener('keydown', function (e) {
             if (e.key === 'Escape' && btn.getAttribute('aria-expanded') === 'true') {
-                btn.setAttribute('aria-expanded', 'false');
+                closeMenu(btn);
                 btn.focus(); /*Move focus back to button*/
             }
         });

--- a/_includes/partials/navbar.html
+++ b/_includes/partials/navbar.html
@@ -38,7 +38,7 @@
     </nav>
 
     <button id="language_switcher_button" type="button" aria-label="{{language_switcher_button}}" aria-expanded="false" aria-controls="language_switcher"><img src="/assets/{{page.lang}}.svg" alt="{{[current_lang_flag_alt]}}"></button>
-    <nav id="language_switcher">
+    <nav id="language_switcher" inert>
         <ul>
             <li class="language"><a href="{{page.url | translateURL: second_lang}}"><img src="/assets/{{second_lang}}.svg" alt="{{[second_lang_flag_alt]}}" loading="lazy"></a></li>
         </ul>
@@ -52,6 +52,9 @@
 
 <script type="module">
     const buttons = ['nav_menu_button', 'language_switcher_button'];
+    const navMenu = document.getElementById('nav_menu');
+    const navButton = document.getElementById('nav_menu_button');
+    const mobileMediaQuery = window.matchMedia('(width <= 600px)');
 
     function closeMenu(btn) {
         const menu = document.getElementById(btn.getAttribute('aria-controls'));
@@ -72,6 +75,20 @@
 
         btn.setAttribute('aria-expanded', 'true');
         menu.removeAttribute('inert');
+    }
+
+    /*Sync nav_menu inert with desktop/mobile layout*/
+    function syncInertState() {
+        if (mobileMediaQuery.matches) {
+            /*Mobile: closed nav menu uninteractable*/
+            if (navButton.getAttribute('aria-expanded') !== 'true') {
+                navMenu.setAttribute('inert', '');
+            }
+        } else {
+            /*Desktop: nav always interactive*/
+            navMenu.removeAttribute('inert');
+            navButton.setAttribute('aria-expanded', 'false');
+        }
     }
 
     for (const btnId of buttons) {
@@ -108,4 +125,9 @@
             }
         }
     });
+
+    /*Sync nav_menu inert when desktop/mobile layout switched*/
+    mobileMediaQuery.addEventListener('change', syncInertState);
+
+    syncInertState();
 </script>

--- a/_includes/partials/navbar.html
+++ b/_includes/partials/navbar.html
@@ -59,7 +59,7 @@
     function closeMenu(btn) {
         const menu = document.getElementById(btn.getAttribute('aria-controls'));
 
-        menu.setAttribute('inert', ''); /*Unlike visibility, immediately makes menu items uninteractive during close animation*/
+        menu.setAttribute('inert', ''); /*Unlike visibility, immediately disable menu interaction during close animation*/
         btn.setAttribute('aria-expanded', 'false');
     }
 
@@ -85,7 +85,7 @@
                 navMenu.setAttribute('inert', '');
             }
         } else {
-            /*Desktop: nav always interactive*/
+            /*Desktop: nav menu always interactive*/
             navMenu.removeAttribute('inert');
             navButton.setAttribute('aria-expanded', 'false');
         }

--- a/_includes/partials/navbar.html
+++ b/_includes/partials/navbar.html
@@ -120,10 +120,7 @@
     /*Clicking outside of a menu closes it*/
     document.addEventListener('click', function (e) {
         for (const {btn, menu} of controls) {
-            const clickInsideButton = btn.contains(e.target);
-            const clickInsideMenu = menu.contains(e.target);
-
-            if (!clickInsideButton && !clickInsideMenu) {
+            if (!btn.contains(e.target) && !menu.contains(e.target)) {
                 closeMenu(btn, menu);
             }
         }

--- a/_includes/partials/navbar.html
+++ b/_includes/partials/navbar.html
@@ -101,15 +101,21 @@
                 openMenu(btn);
             }
         });
-
-        /*Escape key closes menu*/
-        document.addEventListener('keydown', function (e) {
-            if (e.key === 'Escape' && btn.getAttribute('aria-expanded') === 'true') {
-                closeMenu(btn);
-                btn.focus(); /*Move focus back to button*/
-            }
-        });
     }
+
+    /*Escape key closes menu*/
+    document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape') {
+            for (const btnId of buttons) {
+                const btn = document.getElementById(btnId);
+
+                if (btn.getAttribute('aria-expanded') === 'true') {
+                    closeMenu(btn);
+                    btn.focus(); /*Move focus back to button*/
+                }
+            }
+        }
+    });
 
     /*Clicking outside of a menu closes it*/
     document.addEventListener('click', function (e) {

--- a/_includes/partials/navbar.html
+++ b/_includes/partials/navbar.html
@@ -50,7 +50,7 @@
     </picture>
 </header>
 
-<script>
+<script type="module">
     const buttons = ['nav_menu_button', 'language_switcher_button'];
 
     function closeMenu(btn) {

--- a/_includes/partials/navbar.html
+++ b/_includes/partials/navbar.html
@@ -87,4 +87,19 @@
             }
         });
     }
+
+    /*Clicking outside of a menu closes it*/
+    document.addEventListener('click', function (e) {
+        for (const btnId of buttons) {
+            const btn = document.getElementById(btnId);
+            const menu = document.getElementById(btn.getAttribute('aria-controls'));
+
+            const clickInsideButton = btn.contains(e.target);
+            const clickInsideMenu = menu.contains(e.target);
+
+            if (!clickInsideButton && !clickInsideMenu) {
+                closeMenu(btn);
+            }
+        }
+    });
 </script>

--- a/_includes/partials/navbar.html
+++ b/_includes/partials/navbar.html
@@ -54,10 +54,15 @@
     const buttons = ['nav_menu_button', 'language_switcher_button'];
 
     function closeMenu(btn) {
+        const menu = document.getElementById(btn.getAttribute('aria-controls'));
+
+        menu.setAttribute('inert', ''); /*Unlike visibility, makes menu items uninteractive during close animation*/
         btn.setAttribute('aria-expanded', 'false');
     }
 
     function openMenu(btn) {
+        const menu = document.getElementById(btn.getAttribute('aria-controls'));
+
         /*Close any other open menu first*/
         for (const btnId of buttons) {
             if (btnId !== btn.id) {
@@ -66,6 +71,7 @@
         };
 
         btn.setAttribute('aria-expanded', 'true');
+        menu.removeAttribute('inert');
     }
 
     for (const btnId of buttons) {

--- a/_includes/partials/navbar.html
+++ b/_includes/partials/navbar.html
@@ -120,7 +120,7 @@
     /*Clicking outside of a menu closes it*/
     document.addEventListener('click', function (e) {
         for (const {btn, menu} of controls) {
-            if (!btn.contains(e.target) && !menu.contains(e.target)) {
+            if (btn.getAttribute('aria-expanded') === 'true' && !btn.contains(e.target) && !menu.contains(e.target)) {
                 closeMenu(btn, menu);
             }
         }

--- a/_includes/partials/navbar.html
+++ b/_includes/partials/navbar.html
@@ -68,7 +68,7 @@
             if (btnId !== btn.id) {
                 closeMenu(document.getElementById(btnId));
             }
-        };
+        }
 
         btn.setAttribute('aria-expanded', 'true');
         menu.removeAttribute('inert');

--- a/_includes/partials/navbar.html
+++ b/_includes/partials/navbar.html
@@ -52,24 +52,26 @@
 
 <script type="module">
     const buttons = ['nav_menu_button', 'language_switcher_button'];
-    const navMenu = document.getElementById('nav_menu');
-    const navButton = document.getElementById('nav_menu_button');
+    const controls = buttons.map(btnId => {
+        const btn = document.getElementById(btnId);
+
+        return {
+            btn,
+            menu: document.getElementById(btn.getAttribute('aria-controls'))
+        };
+    });
     const mobileMediaQuery = window.matchMedia('(width <= 600px)');
 
-    function closeMenu(btn) {
-        const menu = document.getElementById(btn.getAttribute('aria-controls'));
-
+    function closeMenu(btn, menu) {
         menu.setAttribute('inert', ''); /*Unlike visibility, immediately disable menu interaction during close animation*/
         btn.setAttribute('aria-expanded', 'false');
     }
 
-    function openMenu(btn) {
-        const menu = document.getElementById(btn.getAttribute('aria-controls'));
-
+    function openMenu(btn, menu) {
         /*Close any other open menu first*/
-        for (const btnId of buttons) {
-            if (btnId !== btn.id) {
-                closeMenu(document.getElementById(btnId));
+        for (const control of controls) {
+            if (control.btn !== btn) {
+                closeMenu(control.btn, control.menu);
             }
         }
 
@@ -79,26 +81,26 @@
 
     /*Sync nav_menu inert with desktop/mobile layout*/
     function syncInertState() {
+        const navControl = controls.find(control => control.btn.id === 'nav_menu_button');
+
         if (mobileMediaQuery.matches) {
             /*Mobile: closed nav menu uninteractable*/
-            if (navButton.getAttribute('aria-expanded') !== 'true') {
-                navMenu.setAttribute('inert', '');
+            if (navControl.btn.getAttribute('aria-expanded') !== 'true') {
+                navControl.menu.setAttribute('inert', '');
             }
         } else {
             /*Desktop: nav menu always interactive*/
-            navMenu.removeAttribute('inert');
-            navButton.setAttribute('aria-expanded', 'false');
+            navControl.menu.removeAttribute('inert');
+            navControl.btn.setAttribute('aria-expanded', 'false');
         }
     }
 
-    for (const btnId of buttons) {
-        const btn = document.getElementById(btnId);
-
+    for (const {btn, menu} of controls) {
         btn.addEventListener('click', function () {
             if (btn.getAttribute('aria-expanded') === 'true') {
-                closeMenu(btn);
+                closeMenu(btn, menu);
             } else {
-                openMenu(btn);
+                openMenu(btn, menu);
             }
         });
     }
@@ -106,11 +108,9 @@
     /*Escape key closes menu*/
     document.addEventListener('keydown', function (e) {
         if (e.key === 'Escape') {
-            for (const btnId of buttons) {
-                const btn = document.getElementById(btnId);
-
+            for (const {btn, menu} of controls) {
                 if (btn.getAttribute('aria-expanded') === 'true') {
-                    closeMenu(btn);
+                    closeMenu(btn, menu);
                     btn.focus(); /*Move focus back to button*/
                 }
             }
@@ -119,15 +119,12 @@
 
     /*Clicking outside of a menu closes it*/
     document.addEventListener('click', function (e) {
-        for (const btnId of buttons) {
-            const btn = document.getElementById(btnId);
-            const menu = document.getElementById(btn.getAttribute('aria-controls'));
-
+        for (const {btn, menu} of controls) {
             const clickInsideButton = btn.contains(e.target);
             const clickInsideMenu = menu.contains(e.target);
 
             if (!clickInsideButton && !clickInsideMenu) {
-                closeMenu(btn);
+                closeMenu(btn, menu);
             }
         }
     });

--- a/_includes/partials/navbar.html
+++ b/_includes/partials/navbar.html
@@ -7,8 +7,8 @@
     {% assign livingPages = "Living pages" -%}
     {% assign aboutThisSite = "About this site" -%}
     {% assign FS_alt = "logo" -%}
-    {% assign nav_menu_label = "Open/close navigation menu" -%}
-    {% assign language_switcher_label = "Change language" -%}
+    {% assign nav_menu_button = "Open/close navigation menu" -%}
+    {% assign language_switcher_button = "Change language" -%}
 
     {% assign second_lang = "es" -%}
 {% else -%}
@@ -17,8 +17,8 @@
     {% assign livingPages = "Páginas vivas" -%}
     {% assign aboutThisSite = "Sobre esta web" -%}
     {% assign FS_alt = "logotipo" -%}
-    {% assign nav_menu_label = "Abrir/cerrar el menú de navegación" -%}
-    {% assign language_switcher_label = "Cambiar el idioma" -%}
+    {% assign nav_menu_button = "Abrir/cerrar el menú de navegación" -%}
+    {% assign language_switcher_button = "Cambiar el idioma" -%}
 
     {% assign second_lang = "en" -%}
 {% endif -%}
@@ -27,8 +27,7 @@
 {% assign second_lang_flag_alt = second_lang | append: "_alt_flag" %}
 
 <header class="navbar" title="navbar">
-    <input type="checkbox" id="nav_menu_checkbox">
-    <label for="nav_menu_checkbox" id="nav_menu_checkbox_label" aria-label="{{nav_menu_label}}">≡</label>
+    <button id="nav_menu_button" type="button" aria-label="{{nav_menu_button}}" aria-expanded="false" aria-controls="nav_menu">≡</button>
     <nav id="nav_menu">
         <ul>
             <li class="nav_element"><a href="{{'/' | localiseURL: page.lang}}">{{home}}</a></li>
@@ -38,8 +37,7 @@
         </ul>
     </nav>
 
-    <input type="checkbox" id="language_switcher_checkbox">
-    <label for="language_switcher_checkbox" id="language_switcher_checkbox_label"  aria-label="{{language_switcher_label}}"><img src="/assets/{{page.lang}}.svg" alt="{{[current_lang_flag_alt]}}"></label>
+    <button id="language_switcher_button" type="button" aria-label="{{language_switcher_button}}" aria-expanded="false" aria-controls="language_switcher"><img src="/assets/{{page.lang}}.svg" alt="{{[current_lang_flag_alt]}}"></button>
     <nav id="language_switcher">
         <ul>
             <li class="language"><a href="{{page.url | translateURL: second_lang}}"><img src="/assets/{{second_lang}}.svg" alt="{{[second_lang_flag_alt]}}" loading="lazy"></a></li>
@@ -51,3 +49,16 @@
         <img src="/assets/logo-120.webp" alt="FormularSumo {{FS_alt}}" class="navbar_logo">
     </picture>
 </header>
+
+<script>
+    const buttons = ['nav_menu_button', 'language_switcher_button'];
+
+    for (const btnId of buttons) {
+        const btn = document.getElementById(btnId);
+
+        btn.addEventListener('click', function () {
+            const btnState = btn.getAttribute('aria-expanded') === 'true';
+            btn.setAttribute('aria-expanded', String(!btnState));
+        });
+    }
+</script>

--- a/_includes/partials/navbar.html
+++ b/_includes/partials/navbar.html
@@ -60,5 +60,13 @@
             const btnState = btn.getAttribute('aria-expanded') === 'true';
             btn.setAttribute('aria-expanded', String(!btnState));
         });
+
+        /*Escape key closes menu*/
+        document.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape' && btn.getAttribute('aria-expanded') === 'true') {
+                btn.setAttribute('aria-expanded', 'false');
+                btn.focus(); /*Move focus back to button*/
+            }
+        });
     }
 </script>

--- a/_includes/partials/navbar.html
+++ b/_includes/partials/navbar.html
@@ -51,8 +51,7 @@
 </header>
 
 <script type="module">
-    const buttons = ['nav_menu_button', 'language_switcher_button'];
-    const controls = buttons.map(btnId => {
+    const controls = ['nav_menu_button', 'language_switcher_button'].map(btnId => {
         const btn = document.getElementById(btnId);
 
         return {

--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -201,7 +201,7 @@
         transform: scaleY(0.0002); /*FF bug https://bugzilla.mozilla.org/show_bug.cgi?id=1964076. 0.002 is min value to prevent drawing behind other elements.*/
         z-index: 2;
         background-color: var(--navbar_color);
-        visibility: hidden; /*Completely hide and remove from accessibility tree*/
+        visibility: hidden; /*Completely hide*/
         transition: transform 0.25s, visibility 0s 0.25s;
     }
     #language_switcher_button[aria-expanded="true"] ~ #language_switcher {
@@ -253,7 +253,7 @@
             ul {
                 flex-direction: column;
             }
-            visibility: hidden; /*Completely hide and remove from accessibility tree*/
+            visibility: hidden; /*Completely hide*/
             transition: transform 0.25s, visibility 0s 0.25s;
         }
         #nav_menu_button[aria-expanded="true"] ~ #nav_menu {

--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -147,17 +147,15 @@
     display: flex;
 
 
-    input {
-        display: none;
-    }
-    label {
+    button {
         user-select: none;
         -webkit-user-select: none;
         cursor: pointer;
+        background: none;
+        border: none;
     }
     nav {
         transform-origin: top;
-        transition-duration: 0.25s;
     }
     ul {
         list-style-type: none; /*remove bullet points*/
@@ -173,7 +171,7 @@
     }
 
     /*NAVIGATION MENU (PAGE LINKS) STYLING*/
-    #nav_menu_checkbox_label {
+    #nav_menu_button {
         display: none;
     }
     #nav_menu {
@@ -193,7 +191,7 @@
     }
 
     /*LANGUAGE SWITCHER MENU (FLAGS) STYLING*/
-    #language_switcher_checkbox_label {
+    #language_switcher_button {
         padding-inline: 10px;
     }
     #language_switcher {
@@ -203,9 +201,13 @@
         transform: scaleY(0.0002); /*FF bug https://bugzilla.mozilla.org/show_bug.cgi?id=1964076. 0.002 is min value to prevent drawing behind other elements.*/
         z-index: 2;
         background-color: var(--navbar_color);
+        visibility: hidden; /*Completely hide and remove from accessibility tree*/
+        transition: transform 0.25s, visibility 0s 0.25s;
     }
-    #language_switcher_checkbox:checked ~ #language_switcher {
+    #language_switcher_button[aria-expanded="true"] ~ #language_switcher {
         transform: scaleY(1);
+        visibility: visible;
+        transition: transform 0.25s, visibility 0s;
     }
     .language {
         border-top: 1px solid #4f4f66;
@@ -230,12 +232,13 @@
         }
 
         /*NAVIGATION MENU (PAGE LINKS) STYLING*/
-        #nav_menu_checkbox_label {
+        #nav_menu_button {
             display: inline;
             flex-basis: 100%;
             padding-left: 20px;
             padding-right: 10px;
             line-height: var(--navbar_height);
+            text-align: left;
             color: white;
             font-size: 38px;
             font-family: monospace;
@@ -250,9 +253,13 @@
             ul {
                 flex-direction: column;
             }
+            visibility: hidden; /*Completely hide and remove from accessibility tree*/
+            transition: transform 0.25s, visibility 0s 0.25s;
         }
-        #nav_menu_checkbox:checked ~ #nav_menu {
+        #nav_menu_button[aria-expanded="true"] ~ #nav_menu {
             transform: scaleY(1);
+            visibility: visible;
+            transition: transform 0.25s, visibility 0s;
         }
         .nav_element {
             text-align: left;


### PR DESCRIPTION
# Changes
This improves the accessibility of the main navigation menu and the language switcher in a few important ways:

- Menu buttons are buttons rather than checkboxes+labels
- The menus are correctly in the accessibility tree, which means they're fully navigable with a keyboard (tab, enter, esc) and accurately announced to screen readers
- Opening one menu closes the other one
- Clicking outside of the menus closes them
- Menus are completely hidden (visibility) and non-interactive (inert) when closed

# Performance
The downside to this is that it's more complicated, and some JavaScript is used (previous approach CSS only), but that's definitely worth it for the improvements. The actual performance difference as measured by WPT is small (on the homepage):

HTML: 2.6 --> 3.4 KB
CSS: 2.3 --> 2.4 KB
Images: 68 KB (unchanged)
Total: 72.25 --> 73.09 KB (+~1%)

Time spent processing (Moto G Power): 380 --> 388 ms (+~2%)

Chrome's task manager shows a fairly consistent ~1-2 MB increase in RAM; 43.7 --> 44.7 MB when idle (+~2%). Firefox's (which rounds to the nearest MB) also tends to show a 1 MB increase.

# Alternatives

I tried adding tabindex to the existing labels, but as labels aren't interactive elements, enter doesn't work on them (so I'd have to add a listener at which point using a button in simpler).

I also tried using details/summary, which worked well for keyboard navigation, but created other issues. Using display: contents, only the label was clickable, not the rest of the navbar. Using display: block broke the open/close animation, the menu just went between hidden and fully visible.